### PR TITLE
Fix: neovim ssh

### DIFF
--- a/home/private_dot_config/nvim/init.lua
+++ b/home/private_dot_config/nvim/init.lua
@@ -24,25 +24,7 @@ require("tabs")
 require("keymaps")
 
 -- Clipboard with OSC52, require neovim 0.10+
-local is_tmux_session = vim.env.TERM_PROGRAM == "tmux" -- Tmux is its own clipboard provider which directly works.
--- TMUX documentation about its clipboard - https://github.com/tmux/tmux/wiki/Clipboard#the-clipboard
-if vim.env.SSH_TTY and not is_tmux_session then
-  local function paste()
-    return { vim.fn.split(vim.fn.getreg(""), "\n"), vim.fn.getregtype("") }
-  end
-  local osc52 = require("vim.ui.clipboard.osc52")
-  vim.g.clipboard = {
-    name = "OSC 52",
-    copy = {
-      ["+"] = osc52.copy("+"),
-      ["*"] = osc52.copy("*"),
-    },
-    paste = {
-      ["+"] = paste,
-      ["*"] = paste,
-    },
-  }
-end
+vim.g.clipboard = 'osc52'
 
 vim.opt.clipboard = 'unnamedplus'
 -- end Configuration


### PR DESCRIPTION
fixes
```
module 'vim.ui.clipboard.osc52' not found
```
when running `neovim` in `ssh`